### PR TITLE
fixed sign extension of 'btree_u64_from_big' funcation

### DIFF
--- a/btree.c
+++ b/btree.c
@@ -151,10 +151,10 @@ uint64_t btree_u64_from_big(unsigned char *buf) {
     val |= (uint64_t) buf[1] << 48;
     val |= (uint64_t) buf[2] << 40;
     val |= (uint64_t) buf[3] << 32;
-    val |= buf[4] << 24;
-    val |= buf[5] << 16;
-    val |= buf[6] << 8;
-    val |= buf[7];
+    val |= (uint64_t) buf[4] << 24;
+    val |= (uint64_t) buf[5] << 16;
+    val |= (uint64_t) buf[6] << 8;
+    val |= (uint64_t) buf[7];
     return val;
 }
 


### PR DESCRIPTION
val |= buf[i] << 24;
here, 'cltq' instruction will full fill upper 32 bits with 0xffffffff, if the uint64_t val is 12345678910, we should do a explicit conversion.
tests case is here:https://gist.github.com/shuttler/5916727
