### PR TITLE
Fix use-after-free in "btree_find(...)"

### DIFF
--- a/btree.c
+++ b/btree.c
@@ -973,8 +973,8 @@ int btree_find(struct btree *bt, unsigned char *key, uint64_t *voff) {
             if (cmp <= 0) break;
         }
         if (j < n->numkeys && cmp == 0) {
-            btree_free_node(n);
             if (voff) *voff = n->values[j];
+            btree_free_node(n);
             return 0;
         }
         if (n->isleaf || n->children[j] == 0) {


### PR DESCRIPTION
```
$ valgrind ./btree_example FIND 10 10
==16631== Memcheck, a memory error detector
==16631== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==16631== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==16631== Command: ./btree_example FIND 10 10
==16631== 
Root node is at 57948
==16631== Invalid read of size 8
==16631==    at 0x10BDFB: btree_find (btree.c:977)
==16631==    by 0x109CF7: main (btree_example.c:134)
==16631==  Address 0x5203d98 is 120 bytes inside a block of size 240 free'd
==16631==    at 0x4C2E10B: free (vg_replace_malloc.c:530)
==16631==    by 0x10BDEA: btree_free_node (btree.c:398)
==16631==    by 0x10BDEA: btree_find (btree.c:976)
==16631==    by 0x109CF7: main (btree_example.c:134)
==16631==  Block was alloc'd at
==16631==    at 0x4C2EEF5: calloc (vg_replace_malloc.c:711)
==16631==    by 0x10A7CE: btree_create_node (btree.c:392)
==16631==    by 0x10A7CE: btree_read_node (btree.c:445)
==16631==    by 0x10BD3A: btree_find (btree.c:969)
==16631==    by 0x109CF7: main (btree_example.c:134)
==16631== 
Key found at 57932
Value: 10
==16631== 
==16631== HEAP SUMMARY:
==16631==     in use at exit: 0 bytes in 0 blocks
==16631==   total heap usage: 33 allocs, 33 frees, 58,663 bytes allocated
==16631== 
==16631== All heap blocks were freed -- no leaks are possible
==16631== 
==16631== For counts of detected and suppressed errors, rerun with: -v
==16631== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```