### PR TITLE
Explicitly set alignment to 0, instead of undefined

### DIFF
--- a/btree.c
+++ b/btree.c
@@ -409,7 +409,7 @@ int btree_write_node(struct btree *bt, struct btree_node *n, uint64_t offset) {
     btree_u32_to_big(p,bt->mark); p += 4; /* start mark */
     btree_u32_to_big(p,n->numkeys); p += 4; /* number of keys */
     btree_u32_to_big(p,n->isleaf); p += 4; /* is a leaf? */
-    p += 4; /* unused field, needed for alignment */
+    btree_u32_to_big(p,0); p += 4; /* unused field, needed for alignment */
     memcpy(p,n->keys,sizeof(n->keys)); p += sizeof(n->keys); /* keys */
     /* values */
     for (j = 0; j < BTREE_MAX_KEYS; j++) {


### PR DESCRIPTION
This fixes error messages in tools like valgrind and MemorySanitizer

```
Uninitialized bytes in __interceptor_pwrite at offset 12 inside [0x7ffcd5a80b10, 252)
==4219==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x55dfbc7f2c11 in btree_pwrite ./antirez-otree/btree.c:168:12
    #1 0x55dfbc7f2c11 in btree_write_node ./antirez-otree/btree.c:426
    #2 0x55dfbc7ef8c8 in btree_open ./antirez-otree/btree.c:275:13
```